### PR TITLE
fix varseq add filter and venn steps

### DIFF
--- a/inst/extdata/workflows/varseq/VARseq_helper.R
+++ b/inst/extdata/workflows/varseq/VARseq_helper.R
@@ -181,3 +181,58 @@ normalize_ft <- function(vcf_obj) {
 	vcf_obj
 }
 
+
+filter_vars <- function (files, filter, varcaller = "gatk", organism, out_dir = "results") {
+  stopifnot(is.character(files))
+  stopifnot(is.character(filter) && length(filter) == 1)
+  stopifnot(is.character(organism) && length(organism) == 1)
+  stopifnot(is.character(out_dir) && length(out_dir) == 1)
+  if (!dir.exists(out_dir)) 
+    dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+  if (!dir.exists(out_dir)) 
+    stop("Cannot create output directory", out_dir)
+  if (!all(check_files <- file.exists(files))) 
+    stop("Some files are missing:\n", paste0(files[!check_files], 
+                                             collapse = ",\n"))
+  if (!all(check_ext <- stringr::str_detect(files, "\\.vcf$"))) 
+    stop("filterVars: All files need to end with .vcf\n", 
+         paste0(files[!check_ext], collapse = ",\n"))
+  outfiles <- file.path(out_dir, basename(gsub("\\.vcf", "_filter.vcf", 
+                                               files)))
+  for (i in seq(along = files)) {
+    vcf <- VariantAnnotation::readVcf(files[i], organism)
+    ft <- VariantAnnotation::geno(vcf)$FT
+    if (!is.null(ft) && !isTRUE(is.character(ft))) {
+      ft_vec <- as.character(ft)  # flattens list-like storage
+      ft_clean <- matrix(
+        ft_vec,
+        nrow = nrow(ft),
+        dimnames = dimnames(ft)
+      )
+      VariantAnnotation::geno(vcf)$FT <- ft_clean
+    }
+    vr <- as(vcf, "VRanges")
+    
+    if (varcaller == "gatk") {
+      vrfilt <- vr[eval(parse(text = filter)), ]
+    }
+    if (varcaller == "bcftools") {
+      vrsambcf <- vr
+      vr <- unlist(values(vr)$DP4)
+      vr <- matrix(vr, ncol = 4, byrow = TRUE)
+      VariantAnnotation::totalDepth(vrsambcf) <- as.integer(values(vrsambcf)$DP)
+      VariantAnnotation::refDepth(vrsambcf) <- rowSums(vr[, 
+                                                          1:2])
+      VariantAnnotation::altDepth(vrsambcf) <- rowSums(vr[, 
+                                                          3:4])
+      vrfilt <- vrsambcf[eval(parse(text = filter)), ]
+    }
+    vcffilt <- VariantAnnotation::asVCF(vrfilt)
+    VariantAnnotation::writeVcf(vcffilt, outfiles[i], index = TRUE)
+    print(paste("Generated file", i, gsub(".*/", "", paste0(outfiles[i], 
+                                                            ".bgz"))))
+  }
+  out_paths <- paste0(outfiles, ".bgz")
+  names(out_paths) <- names(files)
+  out_paths
+}

--- a/inst/extdata/workflows/varseq/systemPipeVARseq.Rmd
+++ b/inst/extdata/workflows/varseq/systemPipeVARseq.Rmd
@@ -857,7 +857,7 @@ vr
 
 ### Filter variants in R
 
-The `filterVars` function facilitates flexible, post-hoc filtering of VCF files
+The `filter_vars` function facilitates flexible, post-hoc filtering of VCF files
 based on user-defined quality parameters. This utility sequentially imports
 each VCF file into the R environment, converts the data into an internal
 `VRanges` object, applies the specified filtering logic, and exports the
@@ -881,10 +881,11 @@ re-execute the command-line workflow.
 ```{r filter_vcf, eval=FALSE, spr=TRUE}
 appendStep(sal) <- LineWise(
     code = {
+        source("VARseq_helper.R")
         vcf_raw <- getColumn(sal, "create_vcf")
         library(VariantAnnotation)
         filter <- "totalDepth(vr) >= 20 & (altDepth(vr) / totalDepth(vr) >= 0.8)"
-        vcf_filter <- suppressWarnings(filterVars(vcf_raw, filter, organism = "Homo sapiens", out_dir = "results/vcf_filter"))
+        vcf_filter <- suppressWarnings(filter_vars(vcf_raw, filter, organism = "Homo sapiens", out_dir = "results/vcf_filter"))
     },
     step_name = "filter_vcf",
     dependency = "create_vcf",
@@ -1160,17 +1161,20 @@ comparing 3 samples.
 ```{r venn_diagram, eval=FALSE, spr=TRUE}
 appendStep(sal) <- LineWise(
     code = {
-        top_n <- min(3, length(variant_tables))
-        selected_tables <- variant_tables[seq_len(top_n)]
-        if (is.null(names(selected_tables)) || any(!nzchar(names(selected_tables)))) {
-            names(selected_tables) <- paste0("Sample_", seq_along(selected_tables))
+        unique_samples <- summary_var |> dplyr::distinct(sample) |> dplyr::pull(sample)
+        if (!length(unique_samples)) {
+            stop("No samples available in `summary_var`; cannot draw Venn diagram.")
         }
 
-        variant_sets <- lapply(selected_tables, function(df) {
-            if (!nrow(df)) return(character(0))
-            unique(paste0(df$seqnames, ":", df$start, "_", df$ref, "/", df$alt))
-        })
+        top_n <- min(3, length(unique_samples))
+        selected_samples <- unique_samples[seq_len(top_n)]
 
+        variant_df <- summary_var |>
+            dplyr::filter(sample %in% selected_samples) |>
+            dplyr::distinct(sample, seqnames, start, ref, alt) |>
+            dplyr::mutate(variant_id = paste0(seqnames, ":", start, "_", ref, "/", alt))
+
+        variant_sets <- split(variant_df$variant_id, variant_df$sample)
         vennset <- overLapper(variant_sets, type = "vennsets")
         png("./results/vennplot_var.png")
         vennPlot(vennset, mymain = "Venn Plot of First 3 Samples", mysub = "", colmode = 2, ccol = c("red", "blue"))

--- a/vignettes/systemPipeVARseq.Rmd
+++ b/vignettes/systemPipeVARseq.Rmd
@@ -857,7 +857,7 @@ vr
 
 ### Filter variants in R
 
-The `filterVars` function facilitates flexible, post-hoc filtering of VCF files
+The `filter_vars` function facilitates flexible, post-hoc filtering of VCF files
 based on user-defined quality parameters. This utility sequentially imports
 each VCF file into the R environment, converts the data into an internal
 `VRanges` object, applies the specified filtering logic, and exports the
@@ -881,10 +881,11 @@ re-execute the command-line workflow.
 ```{r filter_vcf, eval=FALSE, spr=TRUE}
 appendStep(sal) <- LineWise(
     code = {
+        source("VARseq_helper.R")
         vcf_raw <- getColumn(sal, "create_vcf")
         library(VariantAnnotation)
         filter <- "totalDepth(vr) >= 20 & (altDepth(vr) / totalDepth(vr) >= 0.8)"
-        vcf_filter <- suppressWarnings(filterVars(vcf_raw, filter, organism = "Homo sapiens", out_dir = "results/vcf_filter"))
+        vcf_filter <- suppressWarnings(filter_vars(vcf_raw, filter, organism = "Homo sapiens", out_dir = "results/vcf_filter"))
     },
     step_name = "filter_vcf",
     dependency = "create_vcf",
@@ -1160,17 +1161,20 @@ comparing 3 samples.
 ```{r venn_diagram, eval=FALSE, spr=TRUE}
 appendStep(sal) <- LineWise(
     code = {
-        top_n <- min(3, length(variant_tables))
-        selected_tables <- variant_tables[seq_len(top_n)]
-        if (is.null(names(selected_tables)) || any(!nzchar(names(selected_tables)))) {
-            names(selected_tables) <- paste0("Sample_", seq_along(selected_tables))
+        unique_samples <- summary_var |> dplyr::distinct(sample) |> dplyr::pull(sample)
+        if (!length(unique_samples)) {
+            stop("No samples available in `summary_var`; cannot draw Venn diagram.")
         }
 
-        variant_sets <- lapply(selected_tables, function(df) {
-            if (!nrow(df)) return(character(0))
-            unique(paste0(df$seqnames, ":", df$start, "_", df$ref, "/", df$alt))
-        })
+        top_n <- min(3, length(unique_samples))
+        selected_samples <- unique_samples[seq_len(top_n)]
 
+        variant_df <- summary_var |>
+            dplyr::filter(sample %in% selected_samples) |>
+            dplyr::distinct(sample, seqnames, start, ref, alt) |>
+            dplyr::mutate(variant_id = paste0(seqnames, ":", start, "_", ref, "/", alt))
+
+        variant_sets <- split(variant_df$variant_id, variant_df$sample)
         vennset <- overLapper(variant_sets, type = "vennsets")
         png("./results/vennplot_var.png")
         vennPlot(vennset, mymain = "Venn Plot of First 3 Samples", mysub = "", colmode = 2, ccol = c("red", "blue"))


### PR DESCRIPTION
@tgirke   
> 22. filter_vcf --> Status: Error -> Message: Error in strsplit(x, ";",
   fixed = TRUE) : non-character argument

This due to we defined some new filteres in the new version of GTAK so when vcf is loaded, some items the `FT` field become a list instead of a character, so the string split failed in VariantAnnotation function. I added the fix to `filterVars` function and renamed it to `filter_vars` in the helper file (changed names in Rmd to use this new func too).  Generally, like you said, get away from `VariantAnnotation`. This is an optional step, doesn't impact downstream if removed (When I tested the wf, I only ran mandatory steps).

> 30. venn_diagram --> Status: Error -> object 'variant_tables' not
   found [ThG comment: this is a bit mysterious because I don't see where
   variant_tables is defined in the WF or code?

This is my fault. I wrapped some steps into functions, `variant_tables ` is one of them and cannot be accessed outside the function. I made the fix. 


Didn't update the html and R file since you may make addtional changes to the Rmd, so better to leave you to update. 